### PR TITLE
chore: Remove JSON stringify Error example

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,7 +766,10 @@ myService.getResource({
     const { result, status, headers, statusText } = response;
     console.log(JSON.stringify(headers, null, 4));
   }).catch((err) => {
-    console.log(JSON.stringify(err, null, 4));
+    if (err.status && err.statusText) {
+      console.log("Error status code: " + err.status + " (" + err.statusText + ")");
+    }
+    console.log("Error message:     " + err.message);
   });
 ```
 </details>


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1647

JSON.stringify does not work on Error so I replaced the example to create a message using the Error fields instead.