### PR TITLE
Fix type for custom headers set on a single request

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,7 +901,7 @@ like this:
 ```go
 options := myService.NewGetResourceOptions("resource-id-1")
 
-customHeaders := make(map[string]interface{})
+customHeaders := make(map[string]string)
 customHeaders["Custom-Header"] = "custom_value"
 
 options.SetHeaders(customHeaders)


### PR DESCRIPTION
This PR fixes a tiny problem I encountered when trying to set a custom header on a request in Go.  The `SetHeaders` method on a Go options model expects `map[string]string`, e.g.
```
// SetHeaders : Allow user to set Headers
func (options *UpdateAccessGroupOptions) SetHeaders(param map[string]string) *UpdateAccessGroupOptions {
	options.Headers = param
	return options
}
```

and throws a build error if the argument is `map[string]interface{}`.

