### PR TITLE
docs(python): improve error handling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1952,16 +1952,16 @@ In the case of an error response from the server endpoint, the Python SDK will t
 with the following fields:  
 - `code`: the HTTP status code that was returned in the response
 - `message`: a message that describes the error
-- `info`: a dictionary of additional information about the error
 
 Here's an example:
 
 ```python
+from ibm_cloud_sdk_core import ApiException
+
 try:
   response = my_service.get_resource(resource_id='does not exist')
 except ApiException as e:
   print("Method failed with status code " + str(e.code) + ": " + e.message)
-  print("Detailed error information: " + e.info)
 ```
 
 </details>


### PR DESCRIPTION
The error handling section does not currently show where the `ApiException`
class comes from, so it's difficult to determine how to define it. Furthermore,
[the `ApiException` class does not actually have an `info` field](https://github.com/IBM/python-sdk-core/blob/main/ibm_cloud_sdk_core/api_exception.py), so the docs
are misleading.

This commit adds an import statement for the class to make it clear and removes
mentions of the non-existent `info` field.