### PR TITLE
build: update .secrets.baseline to avoid warnings

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-02-24T19:30:41Z",
+  "generated_at": "2022-09-14T19:46:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -25,6 +25,7 @@
       "name": "CloudantDetector"
     },
     {
+      "ghe_instance": "github.ibm.com",
       "name": "GheDetector"
     },
     {
@@ -79,7 +80,7 @@
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 193,
         "type": "Private Key",
         "verified_result": null
       }
@@ -89,7 +90,15 @@
         "hashed_secret": "a23e67e43280fb8e135ef32185a4050531f935b5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 321,
+        "line_number": 476,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 682,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -97,7 +106,7 @@
         "hashed_secret": "33515d8639fda6b97c36f87706759ed3af26e97f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1457,
+        "line_number": 2034,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -105,13 +114,13 @@
         "hashed_secret": "32e8612d8ca77c7ea8374aa7918db8e5df9252ed",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1530,
+        "line_number": 2107,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.29.dss",
+  "version": "0.13.1+ibm.51.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
Updates the .secrets.baseline file to avoid warnings from our scanning jobs.